### PR TITLE
Fix for matchdep breaking by missing package.json

### DIFF
--- a/lib/matchdep.js
+++ b/lib/matchdep.js
@@ -24,9 +24,12 @@ function loadConfig(config, props) {
   // current one.
   var callerPath = path.dirname(stackTrace.get(loadConfig)[1].getFileName());
 
-  // If no config defined, resolve to nearest package.json to the calling lib.
+  // If no config defined, resolve to nearest package.json to the calling lib. If not found, throw an error.
   if (config == null) {
     config = findup('package.json', {cwd: callerPath});
+    if (config == null) {
+      throw new Error('No package.json found. Make sure there is a package.json in your project (you can create one with npm init)');
+    }
   }
   // If filename was specified with no path parts, make the path absolute so
   // that resolve doesn't look in node_module directories for it.


### PR DESCRIPTION
Proposed fix for #11 matchdep will break when there is no package.json in the project.

This should do the trick.
