### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,7 @@
   "bugs": {
     "url": "https://github.com/tkellen/node-matchdep/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/tkellen/node-matchdep/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "lib/matchdep",
   "engines": {
     "node": ">= 0.8.0"


### PR DESCRIPTION
Because the npm@v2.10 change

`licenses` is not valid anymore

http://spdx.org/licenses/
https://npm1k.org/
https://github.com/npm/npm/releases/tag/v2.10.0