### PR TITLE
Replace globule with micromatch

### DIFF
--- a/lib/matchdep.js
+++ b/lib/matchdep.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-var globule = require('globule');
+var micromatch = require('micromatch');
 var findup = require('findup-sync');
 var resolve = require('resolve').sync;
 var stackTrace = require('stack-trace');
@@ -71,6 +71,6 @@ Object.keys(methods).forEach(function(method) {
     var search = props.reduce(function(result, prop) {
       return result.concat(config[prop]);
     }, []);
-    return globule.match(pattern, search);
+    return micromatch(search, pattern);
   };
 });

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
   },
   "dependencies": {
     "findup-sync": "~0.3.0",
+    "micromatch": "^2.3.7",
     "resolve": "~1.1.6",
-    "stack-trace": "0.0.9",
-    "globule": "~0.2.0"
+    "stack-trace": "0.0.9"
   },
   "devDependencies": {
+    "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.11.3",
-    "grunt-contrib-nodeunit": "~0.4.1",
-    "grunt": "~0.4.1"
+    "grunt-contrib-nodeunit": "~0.4.1"
   },
   "keywords": [
     "package.json",

--- a/test/matchdep_test.js
+++ b/test/matchdep_test.js
@@ -36,12 +36,12 @@ exports['matchdep'] = {
   },
   'multiple pattern support': function(test) {
     test.expect(1);
-    test.equal(matchdep.filterAll(['*','!globule']).join(), 'findup-sync,resolve,stack-trace,grunt-contrib-jshint,grunt-contrib-nodeunit,grunt', 'should find everything except globule');
+    test.equal(matchdep.filterAll(['*','!micromatch']).join(), 'findup-sync,resolve,stack-trace,grunt,grunt-contrib-jshint,grunt-contrib-nodeunit', 'should find everything except micromatch');
     test.done();
   },
   'default to package.json': function(test) {
     test.expect(1);
-    test.equal(matchdep.filter('*').join(), 'findup-sync,resolve,stack-trace,globule', 'should find all dependencies and devDependencies matching "*"');
+    test.equal(matchdep.filter('*').join(), 'findup-sync,micromatch,resolve,stack-trace', 'should find all dependencies and devDependencies matching "*"');
     test.done();
   },
   'path is relative to calling module, not cwd': function(test) {
@@ -50,7 +50,7 @@ exports['matchdep'] = {
     test.equal(submodule.defaultConfig().join(), 'pkg-1,pkg-2,pkg-3', 'should find all deps in package.json next to submodule');
     test.equal(submodule.fileConfig().join(), 'pkg-1,pkg-2,pkg-3', 'should find all deps in package.json next to submodule');
     test.equal(submodule.relativeConfig().join(), 'pkg-1,pkg-2,pkg-3', 'should find all deps in package.json next to submodule');
-    test.equal(submodule.relativeConfig2().join(), 'findup-sync,resolve,stack-trace,globule', 'should find all deps in ../../package.json from submodule');
+    test.equal(submodule.relativeConfig2().join(), 'findup-sync,micromatch,resolve,stack-trace', 'should find all deps in ../../package.json from submodule');
     test.equal(submodule.absoluteConfig().join(), 'pkg-1,pkg-2,pkg-3', 'should find all deps in package.json next to submodule');
     test.done();
   },


### PR DESCRIPTION
multimatch do the same but it's not dead and doesn't have deprecated dependencies.