### PR TITLE
ci: test on Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
   - "6"
   - "8"
+  - "10"
+  - "node"
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
Node 4 and lower already reached their EOL. We should test against the latest LTS and stable releases.